### PR TITLE
Add Odin and GLSL support. Setting for default size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The `Image Comments` extension for Visual Studio Code allows you to add images, 
 - **`imageComments.pathMode`** (default: `relativeToFile`)
   - `relativeToFile`: Image paths in comments are interpreted as relative to the file.
   - `relativeToWorkspace`: Image paths in comments are interpreted as relative to the workspace.
+- **`imageComments.defaultSize`** (default: `400`)
+  - The size of the preview image, in pixels. Use `no-scale` to preview the image without scaling it.
 
 To modify this setting, open VS Code settings (`Ctrl + ,`), search for `imageComments.pathMode`, and choose your preferred option.
 
@@ -73,6 +75,7 @@ Or just install the extension from [marketplace](https://marketplace.visualstudi
 - Dart
 - Elixir
 - F#
+- GLSL
 - Go
 - Groovy
 - Haskell
@@ -85,6 +88,7 @@ Or just install the extension from [marketplace](https://marketplace.visualstudi
 - Lua
 - MATLAB
 - Objective-C
+- Odin
 - OCaml
 - Perl
 - PHP

--- a/extension.js
+++ b/extension.js
@@ -59,6 +59,10 @@ const supportedLanguages = {
 		singleLine: ['//'],
 		multiLine: { start: '(*', end: '*)' }
 	},
+	'glsl': {
+		singleLine: ['//'],
+		multiLine: { start: '/*', end: '*/' }
+	},	
 	'go': {
 		singleLine: ['//'],
 		multiLine: { start: '/*', end: '*/' }
@@ -109,6 +113,10 @@ const supportedLanguages = {
 	'ocaml': {
 		multiLine: { start: '(*', end: '*)' }
 	},
+	'odin': {
+		singleLine: ['//'],
+		multiLine: { start: '/*', end: '*/' }
+	},	
 	'perl': {
 		singleLine: ['#'],
 		multiLine: { start: '=pod', end: '=cut' }
@@ -406,6 +414,7 @@ function processComment(commentText, document)
 	// Get the configuration for path mode
 	const config = vscode.workspace.getConfiguration('imageComments');
 	const pathMode = config.get('pathMode', 'relativeToFile');
+	currentTooltipSize = config.get('defaultSize', '400');
 
 	// Resolve the absolute path of the image based on the path mode
 	let imgPath;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"onLanguage:dart",
 		"onLanguage:elixir",
 		"onLanguage:fsharp",
+		"onLanguage:glsl",
 		"onLanguage:go",
 		"onLanguage:groovy",
 		"onLanguage:haskell",
@@ -42,6 +43,7 @@
 		"onLanguage:matlab",
 		"onLanguage:objective-c",
 		"onLanguage:ocaml",
+		"onLanguage:odin",
 		"onLanguage:perl",
 		"onLanguage:php",
 		"onLanguage:powershell",
@@ -74,6 +76,7 @@
 					"elixir",
 					"fsharp",
 					"go",
+					"glsl",
 					"groovy",
 					"haskell",
 					"html",
@@ -86,6 +89,7 @@
 					"matlab",
 					"objective-c",
 					"ocaml",
+					"odin",
 					"perl",
 					"php",
 					"powershell",
@@ -121,6 +125,11 @@
 						"Image paths in comments are relative to the file.",
 						"Image paths in comments are relative to the workspace."
 					]
+				},
+				"imageComments.defaultSize": {
+					"type": "string",
+					"default": "400",
+					"description": "Specifies the default size for the image preview. Use no-scale to avoid scaling it."
 				}
 			}
 		}


### PR DESCRIPTION
Adds support for the Odin and GLSL languages.
It also adds a new setting "imageComments.defaultSize" to specify the desired default size for image previews.